### PR TITLE
Return result of function call in `timeout` on successful execution

### DIFF
--- a/pedal/sandbox/timeout.py
+++ b/pedal/sandbox/timeout.py
@@ -101,7 +101,7 @@ def timeout(duration, func, *args, **kwargs):
             e.__traceback__ = ei[2]
             e.exc_info = target_thread.exc_info
             raise e
-
+        return target_thread.result
 
 # =========================================================================
 


### PR DESCRIPTION
# Problem

I discovered this bug when adopting the new `extra_files` and 
`extra_instructor_files` parameters. I encountered an import error when running every submission to a coding question that uses an import statement with Python module dependencies. Pedal would give feedback that functions that obviously exist were not defined inside a module. Furthermore, the module itself was being displayed by Pedal as `<unknown module name>`. 

As I have learned, Pedal overrides the` __import__` builtin that Python provides that actually implements what “import” means. I see the path of building a sandbox:
1. `pedal/pedal/sandbox/sandbox.py` line 597: `self.mock_function('__import__', mocked.create_import_function(self.report, self))`. The mock is saved in the instance’s `_module_overrides` dictionary until later.
2. The execution of the student code starts with `_execute` on line 181. Before running the student code, `self._start_mocking` (line 524) is called, which in turn calls `self.mock_builtins` (line 511) which copies the saved mocks from step 1 into self.data, which holds the globals that get replaced in the next step.
3. On line 187, `exec(compiled_code, self.data)` is called, with the contents self.data being interpreted to replace the default globals including `__builtins__`.

So, suppose a student submission is being executed. An import statement like `from tools import get_tv_rating` becomes a call to the  `__import__` mock, generated in step 1 by `mocked.create_import_function`. Looking at `pedal/pedal/sandbox/mocked.py`, we see that this function defines and returns a function `restricted_import`. This is the replacement for the built-in import function. According to the conditionals in `restricted_import`: 

1. If the imported module is a part of Pedal, a `RuntimeError` is raised, 
preventing any student code that imports Pedal from being executed.
2. If the file associated with the module being imported is known by Pedal 
(in `report.submission.files`), then the import function is replaced with 
`sandbox._import`. 
3. If the the previous conditions are not met, then restricted_import returns the default implementation of `__import__`. Since Pedal was not given the module, it assumes the module was made accessible in the environment another way.

Before using the new `extra_files` and `extra_instructor_files` parameters, I was exposing the modules to the student code by running it in a temporary directory that was built with the necessary module dependencies inside. This means Pedal was never explicitly given these modules and thus we were in case 3 from above. With the new parameters, we switch to case 2. This means that the bug must lie somewhere in the `sandbox._import` function. 

In the definition of `sandbox._import`, we follow the case `if threaded:` since my code calls `run_job` with `threaded=True`. This calls `timeout` with the `_import` function and its arguments as arguments. The `timeout` function is used to call the function with a time limit so execution is stopped if calling the function takes too long. In the `timeout` function, we finally see the bug:

In the case where the the function finishes on time without an error, the 
return value of the function is never returned by `timeout`. This prevents the imported module from being accessed. The function returning `None` caused the symptom of seeing a module named `<unknown module name>` referenced in the feedback. Due to Pedal's design, this is the first scenario I encountered where that return statement was actually needed.

# Reproduce
Call `timeout`, for example:
`timeout(5, lambda: 'value')` returns None instead of 'value'. 

# Solution
Added the needed return statement `return target_thread.result`. I verified that this solution fixes the described issue I encountered using Pedal in my code analysis pipeline.